### PR TITLE
Replace codecov upload with GitHub Actions artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,9 @@ jobs:
     - name: Run tests with coverage
       run: yarn test:coverage
 
-    - name: Upload coverage to Codecov
+    - name: Upload coverage report as artifact
       if: matrix.node-version == '20.x'
-      uses: codecov/codecov-action@v4
+      uses: actions/upload-artifact@v4
       with:
-        file: ./coverage/lcov.info
-        flags: unittests
-        name: codecov-umbrella
-        fail_ci_if_error: false
+        name: coverage-report
+        path: coverage/


### PR DESCRIPTION
- Remove codecov/codecov-action@v4 step that was causing errors
- Add actions/upload-artifact@v4 to preserve coverage reports
- Coverage reports now available as downloadable artifacts

🤖 Generated with [Claude Code](https://claude.ai/code)